### PR TITLE
Set Copyright Year to 2022

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2021 HashiCorp, Inc.
+Copyright (c) 2022 HashiCorp, Inc.
 
 Mozilla Public License Version 2.0
 ==================================


### PR DESCRIPTION
My team was doing an audit of projects where the copyright year listed doesn't match what we have on file for the project creation (in this case, it appears the project was created in 2022 instead of 2021).  Is that correct? If so, I'd like to update the copyright year to reflect it. If not, let me know and I'll update our tooling to reflect 2021 as the proper year.

Thanks!