### PR TITLE
Upgrade Integrations HCL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@actions/core": "^1.10.0",
         "@actions/github": "^5.1.1",
-        "@hashicorp/integrations-hcl": "0.5.0",
+        "@hashicorp/integrations-hcl": "0.6.0",
         "@vercel/fetch": "^6.2.0",
         "node-fetch": "^2.6.7"
       },
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@hashicorp/integrations-hcl": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/integrations-hcl/-/integrations-hcl-0.5.0.tgz",
-      "integrity": "sha512-xlOfoXMGV3qPx3WD/Nc6AlaJ+jmbaeaAQwyQ07Mf7keNPOifShZZ+Tk9HdldoYLoopWiWb0g/vs//H3PeeJg+Q==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/integrations-hcl/-/integrations-hcl-0.6.0.tgz",
+      "integrity": "sha512-vgUn6c+OsoYGVZ/O20+bI3jS4kQu/lsAc9UVDCATDPlToZB+F8S8GbzjEyVuXueEybLuzVSdY+5oi/+BtNncUA==",
       "dependencies": {
         "@vercel/fetch": "^6.2.0",
         "glob": "^10.2.1",
@@ -854,9 +854,9 @@
       }
     },
     "@hashicorp/integrations-hcl": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/integrations-hcl/-/integrations-hcl-0.5.0.tgz",
-      "integrity": "sha512-xlOfoXMGV3qPx3WD/Nc6AlaJ+jmbaeaAQwyQ07Mf7keNPOifShZZ+Tk9HdldoYLoopWiWb0g/vs//H3PeeJg+Q==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/integrations-hcl/-/integrations-hcl-0.6.0.tgz",
+      "integrity": "sha512-vgUn6c+OsoYGVZ/O20+bI3jS4kQu/lsAc9UVDCATDPlToZB+F8S8GbzjEyVuXueEybLuzVSdY+5oi/+BtNncUA==",
       "requires": {
         "@vercel/fetch": "^6.2.0",
         "glob": "^10.2.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.1.1",
-    "@hashicorp/integrations-hcl": "0.5.0",
+    "@hashicorp/integrations-hcl": "0.6.0",
     "@vercel/fetch": "^6.2.0",
     "node-fetch": "^2.6.7"
   }


### PR DESCRIPTION
Upgrade to our latest [integrations-hcl](https://github.com/hashicorp/web-platform-packages/pull/223/files) release.

Additionally re-running `npm run build` to get the changes in our ncc compiled js file.