### PR TITLE
add more details on notify release error

### DIFF
--- a/lib/notify-release.ts
+++ b/lib/notify-release.ts
@@ -50,8 +50,9 @@ export async function main() {
   if (result.status < 300) {
     core.info("Successfully notified release");
   } else {
+    core.error(await result.text());
     core.setFailed(
-      `Failed to notify release: API responded with [${result.status}]\n${await result.text()}`
+      `Failed to notify release: API responded with [${result.status}]}`
     );
   }
 

--- a/lib/notify-release.ts
+++ b/lib/notify-release.ts
@@ -51,7 +51,7 @@ export async function main() {
     core.info("Successfully notified release");
   } else {
     core.setFailed(
-      `Failed to notify release: API responded with [${result.status}]`
+      `Failed to notify release: API responded with [${result.status}]\n${await result.text()}`
     );
   }
 

--- a/lib/notify-release.ts
+++ b/lib/notify-release.ts
@@ -50,9 +50,8 @@ export async function main() {
   if (result.status < 300) {
     core.info("Successfully notified release");
   } else {
-    core.error(await result.text());
     core.setFailed(
-      `Failed to notify release: API responded with [${result.status}]}`
+      `Failed to notify release: API responded with [${result.status}]}\n${await result.text()}`
     );
   }
 


### PR DESCRIPTION
in case of error in notify release only the status code is shown, this adds the error message as well, it looks like this in the run logs:

![image](https://github.com/hashicorp/integration-release-action/assets/1198854/610cc049-3e78-46a9-bfa9-2e6dc28915e5)
